### PR TITLE
Fix GTK theme parse error

### DIFF
--- a/Irradiance-X/gtk-3.0/apps/unity.css
+++ b/Irradiance-X/gtk-3.0/apps/unity.css
@@ -26,7 +26,7 @@ UnityDecoration.top {
     padding: 1px 6px 0 6px;
 
     box-shadow: inset 0 0 transparent, inset 0 0 transparent,
-                inset 0 1px shade (rgba @dark_bg_color, 1.12), inset 0 0 transparent;
+                inset 0 1px shade (@dark_bg_color, 1.12), inset 0 0 transparent;
 
     background-color: transparent;
     background-clip: border-box;


### PR DESCRIPTION
The Irradiance-X unity.css file has an incorrect shade definition for the
box-shadow entry in the UnityDecoration.top section.  There is an extraneous
rgba before the reference to @darg_bg_color.
